### PR TITLE
Reparación de incidente GlobalKeys

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,3 +1,5 @@
 description: This file stores settings for Dart & Flutter DevTools.
 documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
 extensions:
+  - provider: true
+  - shared_preferences: true

--- a/lib/vistas/vista_inicio.dart
+++ b/lib/vistas/vista_inicio.dart
@@ -31,6 +31,7 @@ class _EstadoVistaInicio extends State<VistaInicio> {
 
   final List<TargetFocus> _objetivos = [];
   TutorialCoachMark? _tutorialCoachMark;
+  bool _esPrimerUso = true;
 
   @override
   void initState() {
@@ -53,6 +54,7 @@ class _EstadoVistaInicio extends State<VistaInicio> {
     final SharedPreferences prefs = await SharedPreferences.getInstance();
     const String clavePrimerUsoTutorial = 'primerUsoTutorial';
     bool esPrimerUso = prefs.getBool(clavePrimerUsoTutorial) ?? true;
+    _esPrimerUso = esPrimerUso;
 
     if (esPrimerUso) {
       _definirObjetivosTutorial();
@@ -63,6 +65,9 @@ class _EstadoVistaInicio extends State<VistaInicio> {
         hideSkip: true,
         onClickTarget: (target) async {
           debugPrint("Tocaste el objetivo: ${target.identify}");
+          debugPrint(
+            "Este objetivo tiene clave: ${target.keyTarget.toString()}",
+          );
         },
         onFinish: () async {
           await prefs.setBool(clavePrimerUsoTutorial, false);
@@ -263,6 +268,9 @@ Toca el resumen para ver más estadísticas sobre tus gastos.''',
               onTap: () {
                 // Navegar a VistaEstadisticas (asegúrate de definir la ruta o implementarlo)
                 Navigator.pushNamed(context, '/vistaEstadisticas');
+                debugPrint(
+                  "Navegando a VistaEstadisticas con clave: $_claveVistaResumen",
+                );
               },
               child: ResumenDeGastos(gastos: _gastos),
             ),
@@ -278,7 +286,7 @@ Toca el resumen para ver más estadísticas sobre tus gastos.''',
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        key: _claveVistaGasto,
+        key: _esPrimerUso ? _claveVistaGasto : UniqueKey(),
         tooltip: 'Agregar nuevo gasto',
         onPressed: () async {
           await Navigator.push(

--- a/lib/widgets/tarjeta_gasto.dart
+++ b/lib/widgets/tarjeta_gasto.dart
@@ -23,9 +23,13 @@ class TarjetaGasto extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tema = Theme.of(context);
+    final clave = claveProvista ?? UniqueKey();
+    debugPrint(
+      'Construyendo tarjeta de gasto: ${gasto.descripcion} con clave: $clave',
+    );
 
     return Dismissible(
-      key: claveProvista ?? UniqueKey(),
+      key: clave,
       direction:
           DismissDirection.startToEnd, // Permite deslizar hacia la derecha
       background: Container(


### PR DESCRIPTION
Al eliminar rápidamente varios gastos generaba un error de muchos widgets usando la misma GlobalKey en el botón flotante para agregar gastos.